### PR TITLE
Add clang and add github action to build and upload the docker container to github's registry

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -14,6 +14,7 @@ jobs:
       contents: read
       packages: write
     strategy:
+      fail-fast: false
       matrix:
         image:
           - name: "fedora-34"

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -1,0 +1,49 @@
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches: ['main']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        image:
+          - name: "fedora-34"
+            dockerfile: "ci/ci-fedora-34/Dockerfile"
+          - name: "fedora-35"
+            dockerfile: "ci/ci-fedora-35/Dockerfile"
+          - name: "fedora-36"
+            dockerfile: "ci/ci-fedora-36/Dockerfile"
+          - name: "opensuse-tumbleweed"
+            dockerfile: "ci/ci-opensuse-tumbleweed/Dockerfile"
+          - name: "ubuntu-22.04"
+            dockerfile: "ci/ci-ubuntu-22.04/Dockerfile"
+          - name: "ubuntu-20.04"
+            dockerfile: "ci/ci-ubuntu-20.04/Dockerfile"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ${{ matrix.image.dockerfile }}
+          push: true
+          tags: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.image.name }}"

--- a/ci/ci-fedora-34/Dockerfile
+++ b/ci/ci-fedora-34/Dockerfile
@@ -8,6 +8,7 @@ RUN dnf install --refresh -y \
         cmake \
         gcc \
         gcc-c++ \
+        clang \
 # CPP deps
         boost-devel \
         spdlog-devel \

--- a/ci/ci-fedora-35/Dockerfile
+++ b/ci/ci-fedora-35/Dockerfile
@@ -8,6 +8,7 @@ RUN dnf install --refresh -y \
         cmake \
         gcc \
         gcc-c++ \
+        clang \
 # CPP deps
         boost-devel \
         spdlog-devel \

--- a/ci/ci-fedora-36/Dockerfile
+++ b/ci/ci-fedora-36/Dockerfile
@@ -8,6 +8,7 @@ RUN dnf install --refresh -y \
         cmake \
         gcc \
         gcc-c++ \
+        clang \
 # CPP deps
         boost-devel \
         spdlog-devel \

--- a/ci/ci-opensuse-tumbleweed/Dockerfile
+++ b/ci/ci-opensuse-tumbleweed/Dockerfile
@@ -8,6 +8,7 @@ RUN zypper install -y \
         cmake \
         gcc \
         gcc-c++ \
+        clang \
 # CPP deps
         spdlog-devel \
         fmt-devel \

--- a/ci/ci-ubuntu-20.04/Dockerfile
+++ b/ci/ci-ubuntu-20.04/Dockerfile
@@ -11,6 +11,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
 # CPP deps
 RUN DEBIAN_FRONTEND=noninteractive \
     apt-get install -qy \
+    clang \
     libzmq3-dev \
     doxygen \
     libspdlog-dev \

--- a/ci/ci-ubuntu-20.04/Dockerfile
+++ b/ci/ci-ubuntu-20.04/Dockerfile
@@ -44,8 +44,6 @@ RUN mv /sbin/sysctl /sbin/sysctl.orig \
     doxygen \
     doxygen-latex \
     && rm -f /sbin/sysctl \
-    && ln -s /usr/bin/ccache /usr/lib/ccache/cc \
-    && ln -s /usr/bin/ccache /usr/lib/ccache/c++ \
     && mv /sbin/sysctl.orig /sbin/sysctl
 
 # Testing deps

--- a/ci/ci-ubuntu-22.04/Dockerfile
+++ b/ci/ci-ubuntu-22.04/Dockerfile
@@ -11,6 +11,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
 # CPP deps
 RUN DEBIAN_FRONTEND=noninteractive \
     apt-get install -qy \
+    clang \
     libzmq3-dev \
     doxygen \
     libspdlog-dev \

--- a/ci/ci-ubuntu-22.04/Dockerfile
+++ b/ci/ci-ubuntu-22.04/Dockerfile
@@ -45,8 +45,6 @@ RUN mv /sbin/sysctl /sbin/sysctl.orig \
     doxygen \
     doxygen-latex \
     && rm -f /sbin/sysctl \
-    && ln -s /usr/bin/ccache /usr/lib/ccache/cc \
-    && ln -s /usr/bin/ccache /usr/lib/ccache/c++ \
     && mv /sbin/sysctl.orig /sbin/sysctl
 
 # Testing deps


### PR DESCRIPTION
Trying to get pmt to compile on clang, we noticed that clang is missing in the build containers: https://github.com/gnuradio/pmt/pull/82

This commit adds clang (distribution's default version) to the containers.

I also added a simple github action to build the container and upload it to ghcr.io I'm not that experienced with the Docker ecosystem and don't know how and where it was published before, but I also read about some changes in Docker's open source policy, so this might be a good option. Otherwise I can of course remove the CI part.